### PR TITLE
Prevent division by zero on credit memo

### DIFF
--- a/Block/Adminhtml/Sales/Creditmemo/Create/Totals.php
+++ b/Block/Adminhtml/Sales/Creditmemo/Create/Totals.php
@@ -98,7 +98,7 @@ class Totals extends Template
             'block_name' => $this->getNameInLayout(),
         ]);
 
-        $parent->addTotal($total, 'agjustments');
+        $parent->addTotal($total, 'adjustments');
         return $this;
     }
 

--- a/Model/Total/Creditmemo.php
+++ b/Model/Total/Creditmemo.php
@@ -90,9 +90,11 @@ class Creditmemo extends AbstractTotal
         $rate = $creditmemo->getBaseToOrderRate();
         $customFee = $this->helper->roundPrice($baseCustomFee * $rate);
 
-        $taxRate = $creditmemo->getBaseCodFeeInclTax() / $creditmemo->getBaseCodFee();
+        // Error Division by zero fix edited from this PR:
+        // https://github.com/PHOENIX-MEDIA/Magento2-CashOnDelivery/pull/26/commits/2992740e56150d5e5fb6bf8232a7ad46e7ca656c#diff-3262f248ecabcccaf8f1c6ade805fc61cbffca9a941baf21286c1f6b971be0eaR93
+        $taxRate = $creditmemo->getBaseCodFee() != 0 ? $creditmemo->getBaseCodFeeInclTax() / $creditmemo->getBaseCodFee() : 0;
 
-        if ($this->config->codFeeIncludesTax()) {
+        if ($taxRate > 0 && $this->config->codFeeIncludesTax()) {
             $baseCodFeeInclTax = $baseCustomFee;
             $codFeeInclTax = $customFee;
 

--- a/Model/Total/Creditmemo.php
+++ b/Model/Total/Creditmemo.php
@@ -66,7 +66,7 @@ class Creditmemo extends AbstractTotal
         $this->setCustomRefund($creditmemo);
 
         $isPartialShippingRefunded = $this->isPartialShippingRefunded($creditmemo);
-        if ($isPartialShippingRefunded || $this->config->codFeeIncludesTax()) {
+        if ($isPartialShippingRefunded) {
             $totalBaseCodFee = $creditmemo->getBaseCodFeeInclTax();
             $totalCodFee = $creditmemo->getCodFeeInclTax();
         } else {

--- a/Model/Total/Creditmemo.php
+++ b/Model/Total/Creditmemo.php
@@ -126,7 +126,8 @@ class Creditmemo extends AbstractTotal
     {
         if($creditmemo->getOrder()->getShippingAmount()<=0)
         {
-            return true;
+            //prevent division by zero when the shipping amount is 0
+            return false;
         }
         $part = $creditmemo->getShippingAmount() / $creditmemo->getOrder()->getShippingAmount();
 

--- a/Model/Total/Creditmemo.php
+++ b/Model/Total/Creditmemo.php
@@ -66,7 +66,7 @@ class Creditmemo extends AbstractTotal
         $this->setCustomRefund($creditmemo);
 
         $isPartialShippingRefunded = $this->isPartialShippingRefunded($creditmemo);
-        if ($isPartialShippingRefunded) {
+        if ($isPartialShippingRefunded || $this->config->codFeeIncludesTax()) {
             $totalBaseCodFee = $creditmemo->getBaseCodFeeInclTax();
             $totalCodFee = $creditmemo->getCodFeeInclTax();
         } else {

--- a/Model/Total/Creditmemo.php
+++ b/Model/Total/Creditmemo.php
@@ -124,6 +124,10 @@ class Creditmemo extends AbstractTotal
 
     private function isPartialShippingRefunded(MagentoCreditmemo $creditmemo)
     {
+        if($creditmemo->getOrder()->getShippingAmount()<=0)
+        {
+            return true;
+        }
         $part = $creditmemo->getShippingAmount() / $creditmemo->getOrder()->getShippingAmount();
 
         return $part < 1 && $creditmemo->getOrder()->getShippingTaxAmount() > 0;

--- a/Model/Total/Invoice.php
+++ b/Model/Total/Invoice.php
@@ -18,6 +18,7 @@ namespace Phoenix\CashOnDelivery\Model\Total;
 
 use Magento\Sales\Model\Order\Invoice\Total\AbstractTotal;
 use Phoenix\CashOnDelivery\Helper\Data;
+use Phoenix\CashOnDelivery\Model\Config;
 
 class Invoice extends AbstractTotal
 {
@@ -25,13 +26,16 @@ class Invoice extends AbstractTotal
      * @var Data $helper
      */
     protected $helper;
+    private $codConfig;
 
     public function __construct(
+        Config $codConfig,
         Data $helper,
         array $data = []
     ) {
         parent::__construct($data);
         $this->helper = $helper;
+        $this->codConfig = $codConfig;
     }
 
     /**
@@ -44,8 +48,13 @@ class Invoice extends AbstractTotal
             return $this;
         }
 
-        $baseCodFee = $invoice->getBaseCodFee();
-        $codFee = $invoice->getCodFee();
+        if(!$this->codConfig->codFeeIncludesTax()) {
+            $baseCodFee = $invoice->getBaseCodFee();
+            $codFee = $invoice->getCodFee();
+        } else {
+            $baseCodFee = $invoice->getBaseCodFeeInclTax();
+            $codFee = $invoice->getCodFeeInclTax();
+        }
 
         $invoice->setBaseGrandTotal($invoice->getBaseGrandTotal() + $baseCodFee);
         $invoice->setGrandTotal($invoice->getGrandTotal() + $codFee);

--- a/Model/Total/Invoice.php
+++ b/Model/Total/Invoice.php
@@ -56,6 +56,12 @@ class Invoice extends AbstractTotal
             $codFee = $invoice->getCodFeeInclTax();
         }
 
+        $baseCodTaxAmount = $invoice->getBaseCodTaxAmount();
+        $codTaxAmount = $invoice->getCodTaxAmount();
+
+        $invoice->setTaxAmount($invoice->getTaxAmount() + $codTaxAmount);
+        $invoice->setBaseTaxAmount($invoice->getBaseTaxAmount() + $baseCodTaxAmount);
+
         $invoice->setBaseGrandTotal($invoice->getBaseGrandTotal() + $baseCodFee);
         $invoice->setGrandTotal($invoice->getGrandTotal() + $codFee);
 

--- a/Plugin/Sales/InvoicePlugin.php
+++ b/Plugin/Sales/InvoicePlugin.php
@@ -17,6 +17,7 @@
 namespace Phoenix\CashOnDelivery\Plugin\Sales;
 
 use Magento\Sales\Model\Order\Invoice;
+use Phoenix\CashOnDelivery\Model\Config;
 
 /**
  * Class InvoicePlugin
@@ -25,6 +26,13 @@ use Magento\Sales\Model\Order\Invoice;
  */
 class InvoicePlugin
 {
+    private $codConfig;
+    public function __construct(
+        Config $codConfig
+    ) {
+        $this->codConfig = $codConfig;
+    }
+
     /**
      * Adds invoiced Cash on Delivery fee and tax to order
      *
@@ -38,8 +46,13 @@ class InvoicePlugin
     ) {
         $order = $subject->getOrder();
 
-        $order->setBaseCodFeeInvoiced($order->getBaseCodFeeInvoiced() + $subject->getBaseCodFee());
-        $order->setCodFeeInvoiced($order->getCodFeeInvoiced() + $subject->getCodFee());
+        if($this->codConfig->codFeeIncludesTax()){
+            $order->setBaseCodFeeInvoiced($order->getBaseCodFeeInvoiced() + $subject->getBaseCodFeeInclTax());
+            $order->setCodFeeInvoiced($order->getCodFeeInvoiced() + $subject->getCodFeeInclTax());
+        } else {
+            $order->setBaseCodFeeInvoiced($order->getBaseCodFeeInvoiced() + $subject->getBaseCodFee());
+            $order->setCodFeeInvoiced($order->getCodFeeInvoiced() + $subject->getCodFee());
+        }
 
         $order->setBaseCodTaxAmountInvoiced($order->getBaseCodTaxAmountInvoiced() + $subject->getBaseCodTaxAmount());
         $order->setCodTaxAmountInvoiced($order->getCodTaxAmountInvoiced() + $subject->getCodTaxAmount());
@@ -60,8 +73,13 @@ class InvoicePlugin
     ) {
         $order = $subject->getOrder();
 
-        $order->setBaseCodFeeInvoiced($order->getBaseCodFeeInvoiced() - $subject->getBaseCodFee());
-        $order->setCodFeeInvoiced($order->getCodFeeInvoiced() - $subject->getCodFee());
+        if($this->codConfig->codFeeIncludesTax()){
+            $order->setBaseCodFeeInvoiced($order->getBaseCodFeeInvoiced() - $subject->getBaseCodFeeInclTax());
+            $order->setCodFeeInvoiced($order->getCodFeeInvoiced() - $subject->getCodFeeInclTax());
+        } else {
+            $order->setBaseCodFeeInvoiced($order->getBaseCodFeeInvoiced() - $subject->getBaseCodFee());
+            $order->setCodFeeInvoiced($order->getCodFeeInvoiced() - $subject->getCodFee());
+        }
 
         $order->setBaseCodTaxAmountInvoiced($order->getBaseCodTaxAmountInvoiced() - $subject->getBaseCodTaxAmount());
         $order->setCodTaxAmountInvoiced($order->getCodTaxAmountInvoiced() - $subject->getCodTaxAmount());

--- a/etc/sales.xml
+++ b/etc/sales.xml
@@ -13,7 +13,7 @@
     </section>
     <section name="order_creditmemo">
         <group name="totals">
-            <item name="phoenix_cashondelivery" instance="Phoenix\CashOnDelivery\Model\Total\Creditmemo" sort_order="210"/>
+            <item name="phoenix_cashondelivery" instance="Phoenix\CashOnDelivery\Model\Total\Creditmemo" sort_order="260"/>
         </group>
     </section>
 </config>

--- a/etc/sales.xml
+++ b/etc/sales.xml
@@ -8,7 +8,7 @@
     </section>
     <section name="order_invoice">
         <group name="totals">
-            <item name="phoenix_cashondelivery" instance="Phoenix\CashOnDelivery\Model\Total\Invoice" sort_order="160"/>
+            <item name="phoenix_cashondelivery" instance="Phoenix\CashOnDelivery\Model\Total\Invoice" sort_order="210"/>
         </group>
     </section>
     <section name="order_creditmemo">


### PR DESCRIPTION
It is now possible to create a credit memo on orders with cash on delivery and free shipping.

In this way, we prevent division by zero on credit memo creation when the order has zero shipping amount.